### PR TITLE
Fixes for `repository_in_clean_state`

### DIFF
--- a/checkmk_weblate_syncer/git.py
+++ b/checkmk_weblate_syncer/git.py
@@ -5,10 +5,8 @@ from git import Repo
 
 def repository_in_clean_state(path: Path, branch: str) -> Repo:
     repo = Repo(path)
-    repo.git.clean("-fd")
     repo.git.reset("--hard")
     repo.remotes.origin.fetch()
     repo.git.checkout(branch)
-    repo.git.reset("--hard", "origin")
-    repo.remotes.origin.pull()
+    repo.git.reset("--hard", f"origin/{branch}")
     return repo


### PR DESCRIPTION
* No need to remove untracked files, since they don't bother us.
* Reset to "origin/{branch}" instead of "origin" only to avoid diverging branches.
* `git pull` can be omitted, `git reset` already does the job.